### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -126,7 +126,7 @@ jobs:
   mac-arm64:
     name: release-mac-arm64
     needs: [ui, semantic-release-version-retrieval]
-    runs-on: flyci-macos-large-latest-m1
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).